### PR TITLE
Pr/33 자동 동기화 스케줄러를 구현

### DIFF
--- a/profanity-api/src/test/java/app/fixture/FakeClientMetadataReader.java
+++ b/profanity-api/src/test/java/app/fixture/FakeClientMetadataReader.java
@@ -1,6 +1,6 @@
 package app.fixture;
 
-import app.application.apikey.KeyGenerator;
+import app.application.client.KeyGenerator;
 import app.application.client.MetadataReader;
 import app.core.data.response.constant.StatusCode;
 import app.domain.client.ClientMetadata;

--- a/profanity-api/src/test/java/app/fixture/SecurityFakeStubConfig.java
+++ b/profanity-api/src/test/java/app/fixture/SecurityFakeStubConfig.java
@@ -1,6 +1,6 @@
 package app.fixture;
 
-import app.application.apikey.KeyGenerator;
+import app.application.client.KeyGenerator;
 import app.application.client.MetadataReader;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/profanity-api/src/test/java/app/presentation/SecurityAuthenticationTest.java
+++ b/profanity-api/src/test/java/app/presentation/SecurityAuthenticationTest.java
@@ -1,7 +1,7 @@
 package app.presentation;
 
 import app.TestConfig;
-import app.application.apikey.APIKeyGenerator;
+import app.application.client.APIKeyGenerator;
 import app.core.data.response.constant.StatusCode;
 import app.dto.request.ApiRequest;
 import app.fixture.ApiTestFixture;

--- a/profanity-api/src/test/java/app/restdocs/AbstractRestDocs.java
+++ b/profanity-api/src/test/java/app/restdocs/AbstractRestDocs.java
@@ -1,7 +1,7 @@
 package app.restdocs;
 
 
-import app.application.apikey.APIKeyGenerator;
+import app.application.client.APIKeyGenerator;
 import app.exception.GlobalExceptionHandler;
 import app.security.SecurityContextUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/profanity-domain/build.gradle
+++ b/profanity-domain/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation 'org.ahocorasick:ahocorasick:0.6.3'
     //UUID v7
     implementation 'com.github.f4b6a3:uuid-creator:5.3.3'
+
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}

--- a/profanity-domain/src/main/java/app/application/client/APIKeyGenerator.java
+++ b/profanity-domain/src/main/java/app/application/client/APIKeyGenerator.java
@@ -1,4 +1,4 @@
-package app.application.apikey;
+package app.application.client;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/profanity-domain/src/main/java/app/application/client/ClientMetadataReader.java
+++ b/profanity-domain/src/main/java/app/application/client/ClientMetadataReader.java
@@ -1,6 +1,5 @@
 package app.application.client;
 
-import app.application.apikey.APIKeyGenerator;
 import app.core.data.response.constant.StatusCode;
 import app.domain.client.ClientMetadata;
 import app.domain.client.Clients;

--- a/profanity-domain/src/main/java/app/application/client/ClientsCommandService.java
+++ b/profanity-domain/src/main/java/app/application/client/ClientsCommandService.java
@@ -1,6 +1,5 @@
 package app.application.client;
 
-import app.application.apikey.KeyGenerator;
 import app.core.data.response.constant.StatusCode;
 import app.core.exception.BusinessException;
 import app.domain.client.ClientMetadata;

--- a/profanity-domain/src/main/java/app/application/client/KeyGenerator.java
+++ b/profanity-domain/src/main/java/app/application/client/KeyGenerator.java
@@ -1,4 +1,4 @@
-package app.application.apikey;
+package app.application.client;
 
 import java.security.NoSuchAlgorithmException;
 

--- a/profanity-domain/src/main/java/app/application/manage/SyncScheduler.java
+++ b/profanity-domain/src/main/java/app/application/manage/SyncScheduler.java
@@ -1,0 +1,43 @@
+package app.application.manage;
+
+import app.application.filter.AhocorasickFilter;
+import app.core.data.elapsed.Elapsed;
+import app.core.data.elapsed.ElapsedStartAt;
+import app.domain.profanity.ProfanityRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SyncScheduler {
+    private final AhocorasickFilter syncFilter;
+    private final ProfanityRepository profanityRepository;
+
+    private long count;
+
+    @PostConstruct
+    public void postConstruct() {
+        count = profanityRepository.countAll();
+    }
+
+    /*
+    추후 서버간 중복 스케줄러 방지를 위한 어노테이션
+    @SchedulerLock(name = "synchronizeProfanityData",lockAtLeastFor = "PT10S",     lockAtMostFor = "PT1M")
+    */
+    @Scheduled(fixedDelay = 60000)
+    public void synchronizeProfanityData() {
+        long counted = profanityRepository.countAll();
+        if (counted != count) {
+            log.info("비속어 데이터 변경 감지 - 동기화 시작 [DB: {} -> 서버: {}]", counted, count);
+            ElapsedStartAt start = ElapsedStartAt.now();
+            syncFilter.synchronizeProfanityTrie();
+            Elapsed elapsed = Elapsed.end(start);
+            log.info("스케줄러 동기화 작업이 완료되었습니다. [소요시간: {}ms]", elapsed);
+            count = counted;
+        }
+    }
+}

--- a/profanity-domain/src/main/java/app/config/SchedulerConfig.java
+++ b/profanity-domain/src/main/java/app/config/SchedulerConfig.java
@@ -1,15 +1,23 @@
 package app.config;
 
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+import javax.sql.DataSource;
+
 @Slf4j
 @Configuration
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
 public class SchedulerConfig implements SchedulingConfigurer {
 
     @Override
@@ -29,5 +37,15 @@ public class SchedulerConfig implements SchedulingConfigurer {
 
         log.info("스케줄러가 초기화 되었습니다. [스레드 풀: {}개]", POOL_SIZE);
         taskRegistrar.setTaskScheduler(scheduler);
+    }
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
     }
 }

--- a/profanity-domain/src/main/java/app/config/SchedulerConfig.java
+++ b/profanity-domain/src/main/java/app/config/SchedulerConfig.java
@@ -1,0 +1,33 @@
+package app.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+        // 스케줄러 스레드 풀 사이즈
+        int POOL_SIZE = 3;
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.setThreadNamePrefix("custom-scheduler-");
+        scheduler.setErrorHandler(throwable ->
+                log.error("스케줄러 작업 실행 중 오류가 발생했습니다", throwable)
+        );
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.initialize();
+
+        log.info("스케줄러가 초기화 되었습니다. [스레드 풀: {}개]", POOL_SIZE);
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+}

--- a/profanity-domain/src/main/java/app/domain/profanity/ProfanityRepository.java
+++ b/profanity-domain/src/main/java/app/domain/profanity/ProfanityRepository.java
@@ -12,4 +12,6 @@ public interface ProfanityRepository {
     List<ProfanityWord> findAll();
 
     void deleteAll();
+
+    long countAll();
 }

--- a/profanity-domain/src/test/java/app/application/apikey/ClientsCommandServiceTest.java
+++ b/profanity-domain/src/test/java/app/application/apikey/ClientsCommandServiceTest.java
@@ -1,6 +1,8 @@
 package app.application.apikey;
 
+import app.application.client.APIKeyGenerator;
 import app.application.client.ClientsCommandService;
+import app.application.client.KeyGenerator;
 import app.core.exception.BusinessException;
 import app.domain.InmemoryClientsRepository;
 import app.dto.request.ClientRegistCommand;

--- a/profanity-domain/src/test/java/app/application/apikey/KeyGeneratorTest.java
+++ b/profanity-domain/src/test/java/app/application/apikey/KeyGeneratorTest.java
@@ -1,5 +1,7 @@
 package app.application.apikey;
 
+import app.application.client.APIKeyGenerator;
+import app.application.client.KeyGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/profanity-domain/src/test/java/app/domain/InmemoryProfanityRepository.java
+++ b/profanity-domain/src/test/java/app/domain/InmemoryProfanityRepository.java
@@ -33,4 +33,9 @@ public class InmemoryProfanityRepository implements ProfanityRepository {
     public void deleteAll() {
         repository.clear();
     }
+
+    @Override
+    public long countAll() {
+        return repository.size();
+    }
 }

--- a/profanity-domain/src/test/java/app/fixture/ClientTestFixture.java
+++ b/profanity-domain/src/test/java/app/fixture/ClientTestFixture.java
@@ -1,6 +1,6 @@
 package app.fixture;
 
-import app.application.apikey.KeyGenerator;
+import app.application.client.KeyGenerator;
 import app.domain.client.Clients;
 import app.dto.request.ClientRegistCommand;
 

--- a/profanity-storage/rdb/src/main/java/app/storage/rds/JpaProfanityRepository.java
+++ b/profanity-storage/rdb/src/main/java/app/storage/rds/JpaProfanityRepository.java
@@ -3,6 +3,11 @@ package app.storage.rds;
 import app.domain.profanity.ProfanityRepository;
 import app.domain.profanity.ProfanityWord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaProfanityRepository extends ProfanityRepository, JpaRepository<ProfanityWord, Long> {
+
+    @Override
+    @Query("SELECT COUNT(p) FROM profanity_word p")
+    long countAll();
 }


### PR DESCRIPTION
# 비속어 필터 동기화 기능 개선

## 주요 변경사항
1. 주기적 DB 동기화 구현
   - 1분 간격으로 DB 데이터 변경 여부 확인
   - 변경 감지 시에만 메모리 동기화 수행
   - 각 서버의 메모리 데이터를 최신 상태로 유지

2. 멀티쓰레드 안정성 개선
   - volatile 키워드 적용으로 쓰레드간 가시성 보장
   - 데이터 스왑 시 원자적 교체 방식 적용
   - Trie 자료구조 동시성 제어 추가

3. 분산 환경 고려
   - ShedLock 의존성 추가 (주석 처리)
   - 향후 서버간 중복 실행 방지를 위한 기반 마련

## 기술적 상세
- ThreadPoolTaskScheduler 설정 추가
- 데이터 변경 감지 최적화 (countAll 활용)
- 메모리 자원 관리 개선 (원자적 교체)

-----

>원자적 교체란?
- 새로운 데이터를 완전히 준비한 후에 단 한 번의 참조 변경으로 교체하는 방식
- 다른 스레드가 데이터 교체 중간 상태를 볼 수 없어 항상 일관된 상태 보장
- 업데이트 중 오류가 발생해도 기존 데이터가 안전하게 유지됨